### PR TITLE
Use orchestrator hook to drive audio transcription flow

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,7 @@
+export const ASSEMBLYAI_API_KEY = process.env.REACT_APP_ASSEMBLYAI_API_KEY as string;
+export const ASSEMBLYAI_API_URL = 'https://api.assemblyai.com/v2';
+export const ASSEMBLYAI_POLLING_INTERVAL = 3000;
+export const ASSEMBLYAI_POLLING_TIMEOUT = 30000;
+export const ASSEMBLYAI_UPLOAD_ENDPOINT = `${ASSEMBLYAI_API_URL}/upload`;
+export const ASSEMBLYAI_TRANSCRIPT_ENDPOINT = `${ASSEMBLYAI_API_URL}/transcript`;
+export const ASSEMBLYAI_TRANSCRIPT_POLLING_ENDPOINT = `${ASSEMBLYAI_API_URL}/transcript/:id`;

--- a/src/hooks/transcribe/usePollTranscription.ts
+++ b/src/hooks/transcribe/usePollTranscription.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+import {
+  ASSEMBLYAI_POLLING_INTERVAL,
+  ASSEMBLYAI_TRANSCRIPT_ENDPOINT,
+} from '../../constants';
+
+const ASSEMBLYAI_API_KEY = process.env.REACT_APP_ASSEMBLYAI_API_KEY as string;
+
+export const usePollTranscription = (transcriptId: string | null, enabled: boolean) => {
+  const [pollingEnabled, setPollingEnabled] = useState(enabled);
+
+  useEffect(() => {
+    if (transcriptId !== null) {
+      setPollingEnabled(true);
+    }
+  }, [transcriptId]);
+
+  const query = useQuery({
+    queryKey: ['transcription', transcriptId],
+    queryFn: async () => {
+      const response = await fetch(`${ASSEMBLYAI_TRANSCRIPT_ENDPOINT}/${transcriptId}`, {
+        headers: { authorization: ASSEMBLYAI_API_KEY },
+      });
+      return response.json();
+    },
+    enabled: pollingEnabled && transcriptId !== null,
+    refetchInterval: ASSEMBLYAI_POLLING_INTERVAL,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+
+  useEffect(() => {
+    if (query.data?.status === 'completed' || query.data?.status === 'error') {
+      setPollingEnabled(false);
+    }
+  }, [query.data]);
+
+  return query;
+};

--- a/src/hooks/transcribe/useStartTranscription.ts
+++ b/src/hooks/transcribe/useStartTranscription.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { ASSEMBLYAI_TRANSCRIPT_ENDPOINT } from '../../constants';
+
+const ASSEMBLYAI_API_KEY = process.env.REACT_APP_ASSEMBLYAI_API_KEY as string;
+
+export const useStartTranscription = () =>
+    useMutation({
+      mutationFn: async (audioUrl: string): Promise<{ id: string; status: string }> => {
+        const response = await fetch(ASSEMBLYAI_TRANSCRIPT_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            authorization: ASSEMBLYAI_API_KEY,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ audio_url: audioUrl }),
+        });
+        return response.json();
+      },
+    });

--- a/src/hooks/transcribe/useUploadAudio.ts
+++ b/src/hooks/transcribe/useUploadAudio.ts
@@ -1,0 +1,19 @@
+import { useMutation } from '@tanstack/react-query';
+import { ASSEMBLYAI_UPLOAD_ENDPOINT } from '../../constants';
+
+const ASSEMBLYAI_API_KEY = process.env.REACT_APP_ASSEMBLYAI_API_KEY as string;
+
+export const useUploadAudio = () =>
+    useMutation({
+      mutationFn: async (blob: Blob): Promise<string> => {
+        const response = await fetch(ASSEMBLYAI_UPLOAD_ENDPOINT, {
+          method: 'POST',
+          headers: {
+            authorization: ASSEMBLYAI_API_KEY,
+          },
+          body: blob,
+        });
+        const data = await response.json();
+        return data.upload_url;
+      },
+    });

--- a/src/hooks/useTranscriptionFlow.ts
+++ b/src/hooks/useTranscriptionFlow.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useUploadAudio } from './transcribe/useUploadAudio';
+import { useStartTranscription } from './transcribe/useStartTranscription';
+import { usePollTranscription } from './transcribe/usePollTranscription';
+
+export const useTranscriptionFlow = () => {
+    const [transcriptId, setTranscriptId] = useState<string | null>(null);
+  
+    const { mutate: uploadMutation } = useUploadAudio();
+    const { mutate: startTranscriptionMutation } = useStartTranscription();
+    const pollQuery = usePollTranscription(transcriptId, transcriptId !== null);
+  
+    /**
+     * Runs the full transcription flow:
+     * 1. Uploads the blob.
+     * 2. Starts the transcription.
+     * 3. Sets the transcriptId to enable polling.
+     */
+    const transcribeAudio = async (blob: Blob) => {
+        uploadMutation(blob, {
+            onSuccess: async (data) => {
+                startTranscriptionMutation(data, {
+                    onSuccess: (transcriptData) => {
+                        setTranscriptId(transcriptData.id);
+                    },
+                    onError: (error) => {
+                        console.error('Error starting transcription:', error);
+                    },
+                });
+            },
+            onError: (error) => {
+                console.error('Error uploading audio:', error);
+            },
+        });
+    };
+  
+    return {
+      transcribeAudio,
+      transcriptionData: pollQuery.data, // Contains job status, text (when available), etc.
+      isTranscribing: pollQuery.isLoading,
+      error: pollQuery.error,
+    };
+  };
+  


### PR DESCRIPTION
We introduce a new hook useTranscriptionFlow which runs three subhooks in turn:

- useUploadAudio, this uploads the audio blob to AssemblyAI
- useStartTranscription, this kicks off a transcription job on the AssemblyAI end (once we have an audioUrl from the previous hook)
- usePollTranscription, this polls AssemblyAI until the job has status 'completed'.

The subhooks leverage `@tanstack/react-query@v5`, useMutation for the first two, and useQuery for the third.

I've implemented some basic error handling as well.